### PR TITLE
Dpm xenial r1

### DIFF
--- a/debian/lxcfs.postinst
+++ b/debian/lxcfs.postinst
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -e
+
+# This script can be called in the following ways:
+#
+# After the package was installed:
+#       <postinst> configure <old-version>
+#
+#
+# If prerm fails during upgrade or fails on failed upgrade:
+#       <old-postinst> abort-upgrade <new-version>
+#
+# If prerm fails during deconfiguration of a package:
+#       <postinst> abort-deconfigure in-favour <new-package> <version>
+#                  removing <old-package> <version>
+#
+# If prerm fails during replacement due to conflict:
+#       <postinst> abort-remove in-favour <new-package> <version>
+
+case "$1" in
+    configure)
+        # Request a reboot.  If we restart lxcfs, all containers will
+        # stop working right.
+        [ -x /usr/share/update-notifier/notify-reboot-required ] && \
+            /usr/share/update-notifier/notify-reboot-required
+    ;;
+
+esac
+
+#DEBHELPER#

--- a/debian/lxcfs.service
+++ b/debian/lxcfs.service
@@ -2,8 +2,6 @@
 Description=FUSE filesystem for LXC
 ConditionVirtualization=!container
 Before=lxc.service
-After=cgmanager.service
-Requires=cgmanager.service
 
 [Service]
 ExecStart=/usr/bin/lxcfs /var/lib/lxcfs/

--- a/debian/rules
+++ b/debian/rules
@@ -11,6 +11,12 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 %:
 	dh $@  --with autotools_dev --with autoreconf --with systemd
 
+override_dh_installinit:
+	dh_installinit --no-restart-on-upgrade
+
+override_dh_systemd_start:
+	dh_systemd_start --no-restart-on-upgrade lxcfs.service
+
 override_dh_autoreconf:
 	[ -e m4 ] || mkdir m4
 	dh_autoreconf


### PR DESCRIPTION
Don't restart lxcfs on upgrades. Request a reboot instead. Otherwise, all containers using lxcfs become unusable.

Also no longer wait until cgmanager to start.